### PR TITLE
creating a new object table on each request

### DIFF
--- a/src/InstanceObjectTable.cpp
+++ b/src/InstanceObjectTable.cpp
@@ -205,7 +205,7 @@ void InstanceObjectTable::checkInstance() const {
 InstanceObjectTable::~InstanceObjectTable() {
   if (_instance) { // might have been orphaned
     if (_internal)
-      _instance->invalidateInternalTable();
+      _instance->invalidateInternalTable(sexp());
     else _instance->invalidateSexp();
   }
 }

--- a/src/SmokeObject.cpp
+++ b/src/SmokeObject.cpp
@@ -133,7 +133,7 @@ SmokeObject * SmokeObject::fromSexp(SEXP sexp)
 
 SmokeObject::SmokeObject(void *ptr, const Class *klass, bool allocated)
   : _ptr(ptr), _klass(klass), _allocated(allocated), _sexp(NULL),
-    _internalTable(NULL), _fieldEnv(NULL)
+    _fieldEnv(NULL)
 {
 }
 
@@ -177,12 +177,14 @@ void SmokeObject::invalidateSexp() {
   maybeDestroy();
 }
 
-void SmokeObject::invalidateInternalTable() {
+void SmokeObject::invalidateInternalTable(SEXP sexp) {
 #ifdef MEM_DEBUG
-  qDebug("%p: invalidating internal table %p", this, _internalTable);
+  qDebug("%p: invalidating internal table %p", this, sexp);
 #endif
-  _internalTable = NULL;
-  maybeDestroy();
+  _internalTables.remove(sexp);
+  if (_internalTables.isEmpty()) {
+    maybeDestroy();
+  }
 }
 
 void SmokeObject::castSexp(SEXP sexp) {
@@ -240,7 +242,7 @@ SmokeModule *SmokeObject::module() const {
 bool SmokeObject::memoryIsOwned() const {
   // NOTE: calling the module's memoryIsOwned() might resurrect sexps;
   // if so, they become orphans
-  bool owned = _sexp || _internalTable;
+  bool owned = _sexp || !_internalTables.isEmpty();
   if (!owned) {
     owned = module()->memoryIsOwned(this);
 #ifdef MEM_DEBUG
@@ -249,8 +251,8 @@ bool SmokeObject::memoryIsOwned() const {
 #endif
   }
 #ifdef MEM_DEBUG
-  else qDebug("%p: memory is owned by R, sexp: %p, table: %p", this, _sexp,
-                _internalTable);
+  else qDebug("%p: memory is owned by R, sexp: %p, %d tables", this, _sexp,
+                _internalTables.size());
 #endif
   return owned;
 }
@@ -394,14 +396,14 @@ SEXP SmokeObject::internalSexp(SEXP env) {
 }
 
 SEXP SmokeObject::internalTable() {
-  if (!_internalTable) {
-    InstanceObjectTable *table = _klass->createObjectTable(this);
-    table->setInternal(true);
-    _internalTable = table->sexp();
+  SEXP _internalTable;
+  InstanceObjectTable *table = _klass->createObjectTable(this);
+  table->setInternal(true);
+  _internalTable = table->sexp();
+  _internalTables.insert(_internalTable);
 #ifdef MEM_DEBUG
     qDebug("%p: creating internal table %p", this, _internalTable);
 #endif
-  }
   return _internalTable;
 }
 
@@ -456,11 +458,12 @@ SmokeObject::~SmokeObject() {
 #endif
     orphanSexp();
   }
-  if (_internalTable) {
+  for (QSet<SEXP>::const_iterator it = _internalTables.begin();
+       it != _internalTables.end(); ++it) {
 #ifdef MEM_DEBUG
-    qDebug("%p: orphaned internal table %p", this, _internalTable);
+    qDebug("%p: orphaned internal table %p", this, *it);
 #endif
-    orphanTable(_internalTable);
+    orphanTable(*it);
   }
   if (_fieldEnv)
     R_ReleaseObject(_fieldEnv);

--- a/src/SmokeObject.hpp
+++ b/src/SmokeObject.hpp
@@ -2,6 +2,7 @@
 #define SMOKE_OBJECT_H
 
 #include <QHash>
+#include <QSet>
 #include <smoke.h>
 
 class SmokeModule;
@@ -49,7 +50,7 @@ public:
   SEXP sexp();
   SEXP internalSexp(SEXP env);
   void invalidateSexp();
-  void invalidateInternalTable();
+  void invalidateInternalTable(SEXP sexp);
   SEXP fieldEnv() const;
   
   inline const Class *klass() const { return _klass; }
@@ -85,7 +86,7 @@ private:
   const Class *_klass;
   bool _allocated;
   SEXP _sexp;  
-  SEXP _internalTable;
+  QSet<SEXP> _internalTables;
   mutable SEXP _fieldEnv;
   
   static QHash<void *, SmokeObject *> instances;


### PR DESCRIPTION
Object table of a SmokeObject instance gets not reused, but a fresh copy gets created on each request.
This is a temporary solution to issue #21.
