### PR TITLE
Force optional Qt5 modules to come after smokeqt, so all needed symbols ...

### DIFF
--- a/kdebindings/smoke/qt/CMakeLists.txt
+++ b/kdebindings/smoke/qt/CMakeLists.txt
@@ -44,7 +44,7 @@ CMAKE_FORCE_CXX_COMPILER(${R_CXX} R_CXX)
 qt5_use_modules(smokeqt Widgets)
 
 set(QT_MODULES Multimedia MultimediaWidgets Network Qml Quick Sql Test
-               Webkit WebKitWidgets DBus Svg XmlPatterns
+               WebKit WebKitWidgets DBus Svg XmlPatterns
                PrintSupport Help UiTools SerialPort Sensors
                Bluetooth Nfc Positioning)
 

--- a/kdebindings/smoke/qt/smokeconfig.xml
+++ b/kdebindings/smoke/qt/smokeconfig.xml
@@ -793,7 +793,7 @@
         <class>QTestKeyEvent</class>
         <class>QTestMouseEvent</class>
 
-        <!-- QtWebkitWidgets -->
+        <!-- QtWebKitWidgets -->
         <class>QGraphicsWebView</class>
         <class>QWebPage::ChooseMultipleFilesExtensionOption</class>
         <class>QWebPage::ChooseMultipleFilesExtensionReturn</class>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ macro(qt5_optional_use_modules _target)
 endmacro()
 
 qt5_optional_use_modules(qtbase Multimedia MultimediaWidgets Network Qml Quick
-                         Sql Test Webkit WebKitWidgets DBus Svg XmlPatterns
+                         Sql Test WebKit WebKitWidgets DBus Svg XmlPatterns
                          PrintSupport Help UiTools SerialPort Sensors
                          Bluetooth Positioning Nfc)
 
@@ -99,10 +99,10 @@ if(Qt5Test_FOUND)
   get_target_property(QtTest_location Qt5::Test LOCATION)
   set(LIB_LOC ${LIB_LOC} ${QtTest_location})
 endif(Qt5Test_FOUND)
-if(Qt5Webkit_FOUND)
-  get_target_property(QtWebkit_location Qt5::Webkit LOCATION)
-  set(LIB_LOC ${LIB_LOC} ${QtWebkit_location})
-endif(Qt5Webkit_FOUND)
+if(Qt5WebKit_FOUND)
+  get_target_property(QtWebKit_location Qt5::WebKit LOCATION)
+  set(LIB_LOC ${LIB_LOC} ${QtWebKit_location})
+endif(Qt5WebKit_FOUND)
 if(Qt5WebKitWidgets_FOUND)
   get_target_property(QtWebKitWidgets_location Qt5::WebKitWidgets LOCATION)
   set(LIB_LOC ${LIB_LOC} ${QtWebKitWidgets_location})


### PR DESCRIPTION
...are linked

see issue #16
